### PR TITLE
Build/add python target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,3 +57,36 @@ jobs:
 
       - name: Build
         run: yarn --cwd ts build
+
+  build-python:
+    runs-on: ubuntu-20.04
+    env:
+      WORK_DIR: ./python
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+
+      - name: Install Python Poetry
+        uses: abatilo/actions-poetry@v2.1.4
+        with:
+          poetry-version: 1.1.11
+
+      - name: Install project dependencies
+        working-directory: ${{env.WORK_DIR}}
+        run: |
+          poetry install
+
+      - name: Install project dependencies
+        working-directory: ${{env.WORK_DIR}}
+        run: |
+          mkdir -p okp4_grpc_client
+          poetry run python -m grpc_tools.protoc -I=../proto/cosmos-sdk -I=../proto/okp4 $(find ../proto -type f -name '*.proto' | tr '\n' ' ') --grpc_python_out=gen_python
+
+      - name: Build project
+        working-directory: ${{env.WORK_DIR}}
+        run: |
+          poetry build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         working-directory: ${{env.WORK_DIR}}
         run: |
           mkdir -p okp4_grpc_client
-          poetry run python -m grpc_tools.protoc -I=../proto/cosmos-sdk -I=../proto/okp4 $(find ../proto -type f -name '*.proto' | tr '\n' ' ') --grpc_python_out=gen_python
+          poetry run python -m grpc_tools.protoc -I=../proto/cosmos-sdk -I=../proto/okp4 $(find ../proto -type f -name '*.proto' | tr '\n' ' ') --grpc_python_out=okp4_grpc_client
 
       - name: Build project
         working-directory: ${{env.WORK_DIR}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,8 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: "temurin"
+          java-version: "11"
 
       - name: Configure gradle.properties
         run: |
@@ -112,3 +112,38 @@ jobs:
           "${publish[@]}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+
+  publish-pypi:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: ubuntu-20.04
+    env:
+      WORK_DIR: ./python
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up context
+        id: project_context
+        uses: FranzDiebold/github-env-vars-action@v2.3.1
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+
+      - name: Install Python Poetry
+        uses: abatilo/actions-poetry@v2.1.4
+        with:
+          poetry-version: 1.1.11
+
+      - name: Publish package
+        working-directory: ${{env.WORK_DIR}}
+        run: |
+          poetry install
+
+          mkdir -p okp4_grpc_client
+          poetry run python -m grpc_tools.protoc -I=../proto/cosmos-sdk -I=../proto/okp4 $(find ../proto -type f -name '*.proto' | tr '\n' ' ') --grpc_python_out=okp4_grpc_client
+
+          poetry build
+
+          echo "🚀 Publishing pypi package"
+          poetry publish  -u __token__ -p "${{ secrets.PYPI_API_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 node_modules
 dist
 gen-ts
+okp4_grpc_client

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -11,15 +11,24 @@ plugins:
     - npmPublish: false
       tarballDir: "false"
       pkgRoot: ./ts
-  - - '@google/semantic-release-replace-plugin'
+  - - "@google/semantic-release-replace-plugin"
     - replacements:
         - files:
             - kotlin/gradle.properties
           from: 'project\.version=.*'
-          to: 'project.version=${nextRelease.version}'
+          to: "project.version=${nextRelease.version}"
           countMatches: true
           results:
             - file: kotlin/gradle.properties
+              hasChanged: true
+              numMatches: 1
+              numReplacements: 1
+        - files: [python/pyproject.toml]
+          from: ^version = ".+"
+          to: version = "${nextRelease.version}"
+          countMatches: true
+          results:
+            - file: python/pyproject.toml
               hasChanged: true
               numMatches: 1
               numReplacements: 1

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Generate gRPC clients for multiple targets based on [CØSMOS](https://github.com
 
 - [Kotlin](kotlin/README.md)
 - [Typescript (grpc-web)](ts/README.md)
+- [Python](python/README.md)

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,16 @@
+# ØKP4 CØSMOS proto
+
+> Python gRPC client for ØKP4 and by extension, CØSMOS based blockchains.
+
+[![build](https://github.com/okp4/okp4-cosmos-proto/actions/workflows/build.yml/badge.svg)](https://github.com/okp4/okp4-cosmos-proto/actions/workflows/build.yml)
+[![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
+## Purpose
+
+Provides Python [gRPC clients](https://grpc.io/docs/languages/python/quickstart/) for ØKP4 and by extension, CØSMOS based blockchains generated from their Protobuf definitions.
+
+## Quick Start
+
+```sh
+pip install okp4_grpc_client
+```

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -1,0 +1,190 @@
+[[package]]
+name = "grpcio"
+version = "1.45.0"
+description = "HTTP/2-based RPC framework"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+six = ">=1.5.2"
+
+[package.extras]
+protobuf = ["grpcio-tools (>=1.45.0)"]
+
+[[package]]
+name = "grpcio-tools"
+version = "1.45.0"
+description = "Protobuf code generator for gRPC"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+grpcio = ">=1.45.0"
+protobuf = ">=3.5.0.post1,<4.0dev"
+
+[[package]]
+name = "protobuf"
+version = "3.20.0"
+description = "Protocol Buffers"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "051ce5f65acbdbeacd4f8d2f1eeb025c349c22e28021d74f979e095197568ded"
+
+[metadata.files]
+grpcio = [
+    {file = "grpcio-1.45.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:0d74a159df9401747e57960f0772f4371486e3281919004efa9df8a82985abee"},
+    {file = "grpcio-1.45.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:4e6d15bfdfa28e5f6d524dd3b29c7dc129cfc578505b067aa97574490c5b70fe"},
+    {file = "grpcio-1.45.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:44615be86e5540a18f5e4ca5a0f428d4b1efb800d255cfd9f902a11daca8fd74"},
+    {file = "grpcio-1.45.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8b452f715e2cae9e75cb309f59a37f82e5b25f51f0bfc3cd1462de86265cef05"},
+    {file = "grpcio-1.45.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db1c45daa35c64f17498af1ba6eb1d0a8d88a8a0b6b322f960ab461e7ef0419e"},
+    {file = "grpcio-1.45.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:678a673fe811dad3ed5bd2e2352b79851236e4d718aeaeffc10f372a55954d8d"},
+    {file = "grpcio-1.45.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a5c8a08aff0af770c977dcede62fbed53ae7b99adbc184d5299d148bb04652f1"},
+    {file = "grpcio-1.45.0-cp310-cp310-win32.whl", hash = "sha256:1d764c8a190719301ec6f3b6ddeb48a234604e337d0fbb3184a4ddcda2aca9da"},
+    {file = "grpcio-1.45.0-cp310-cp310-win_amd64.whl", hash = "sha256:797f5b750be6ff2905b9d0529a00c1f873d8035a5d01a9801910ace5f0d52a18"},
+    {file = "grpcio-1.45.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:b46772b7eb58c6cb0b468b56d59618694d2c2f2cee2e5b4e83ae9729a46b8af0"},
+    {file = "grpcio-1.45.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:2f135e5c8e9acd14f3090fd86dccb9d7c26aea7bfbd4528e8a86ff621d39e610"},
+    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:16603b9544a4af135ce4d594a7396602fbe62d1ccaa484b05cb1814c17a3e559"},
+    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ccba925045c00acc9ce2cc645b6fa9d19767dbb16c9c49921013da412b1d3415"},
+    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:7262b9d96db79e29049c7eb2b75b03f2b9485fd838209b5ff8e3cca73b2a706c"},
+    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1c1098f35c33b985c312cacea39e2aa66f7ac1462579eed1d3aed2e51fff00d"},
+    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b18c86a9cfbedd0c4e083690fecc82027b3f938100ed0af8db77d52a171eb1e"},
+    {file = "grpcio-1.45.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:638364d3603df9e4a1dbc2151b5fe1b491ceecda4e1672be86724e1dfa79c44d"},
+    {file = "grpcio-1.45.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8de79eac582431cb6d05ff5652e68089c40aa0e604ec1630fa52ac926bc44f1b"},
+    {file = "grpcio-1.45.0-cp36-cp36m-win32.whl", hash = "sha256:6cf5f1827c182ef9b503d7d01e503c1067f4499d45af792d95ccd1d8b0bea30d"},
+    {file = "grpcio-1.45.0-cp36-cp36m-win_amd64.whl", hash = "sha256:4f1a22744f93b38d393b7a83cb607029ac5e2de680cab39957ffdd116590a178"},
+    {file = "grpcio-1.45.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:321f84dbc788481f7a3cd12636a133ba5f4d17e57f1c906de5a22fd709c971b5"},
+    {file = "grpcio-1.45.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:a33ed7d3e52ddc839e2f020592a4371d805c2ae820fb63b12525058e1810fe46"},
+    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f9f28d8c5343602e1510d4839e38568bcd0ca6353bd98ad9941787584a371a1d"},
+    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3a40dbb8aac60cf6a86583e2ba74fc2c286f1abc7a3404b25dcd12a49b9f7d8b"},
+    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:b00ce58323dde47d2ea240d10ee745471b9966429c97d9e6567c8d56e02b0372"},
+    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bd4944f35f1e5ab54804c3e37d24921ecc01908ef871cdce6bd52995ea4f985c"},
+    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc135b77f384a84bac67a37947886986be136356446338d64160a30c85f20c6d"},
+    {file = "grpcio-1.45.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:35ae55460514ed404ceaa95533b9a79989691b562faf012fc8fb143d8fd16e47"},
+    {file = "grpcio-1.45.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:779db3d00c8da1d3efa942387cb0fea9ac6d50124d656024f82f9faefdd016e3"},
+    {file = "grpcio-1.45.0-cp37-cp37m-win32.whl", hash = "sha256:aea67bd3cbf93db552c725bc0b4db0acdc6a284d036d1cc32d638305e0f01fd9"},
+    {file = "grpcio-1.45.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7fe3ac700cc5ecba9dc9072c0e6cfd2f964ea9f273ce1111eaa27d13aa20ec32"},
+    {file = "grpcio-1.45.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:259c126821fefcda298c020a0d83c4a4edac3cf10b1af12a62d250f8192ea1d1"},
+    {file = "grpcio-1.45.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:5d05cd1b2b0975bb000ba97ca465565158dc211616c9bbbef5d1b77871974687"},
+    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6f2e044a715507fd13c70c928cd90daf8d0295c936a81fd9065a24e58ba7cc7d"},
+    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4d37c526b86c46d229f6117df5dca2510de597ab73c5956bc379ca41f8a1db84"},
+    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:6df338b8d2c328ba91a25e28786d10059dea3bc9115fa1ddad30ba5d459e714a"},
+    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:042921a824e90bf2974dbef7d89937096181298294799fb53e5576d9958884c7"},
+    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb23ed6ed84ae312df03e96c7a7cd3aa5f7e3a1ad7066fdb6cd47f1bd334196c"},
+    {file = "grpcio-1.45.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:79582ec821ef10162348170a6e912d93ea257c749320a162dfc3a132ef25ac1b"},
+    {file = "grpcio-1.45.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d14d372ea5a51d5ab991aa6d499a26e5a1e3b3f3af93f41826ea610f8a276c9e"},
+    {file = "grpcio-1.45.0-cp38-cp38-win32.whl", hash = "sha256:b54444cf4212935a7b98cd26a30ad3a036389e4fd2ff3e461b176af876c7e20b"},
+    {file = "grpcio-1.45.0-cp38-cp38-win_amd64.whl", hash = "sha256:da395720d6e9599c754f862f3f75bc0e8ff29fa55259e082e442a9cc916ffbc3"},
+    {file = "grpcio-1.45.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:add03308fa2d434628aeaa445e0c75cdb9535f39128eb949b1483ae83fafade6"},
+    {file = "grpcio-1.45.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:250d8f18332f3dbd4db00efa91d33d336e58362e9c80e6946d45ecf5e82d95ec"},
+    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:dfca4dfd307b449d0a1e92bc7fbb5224ccf16db384aab412ba6766fc56bdffb6"},
+    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b7f2dc8831045eb0c892bb947e1cba2b1ed639e79a54abff7c4ad90bdd329f78"},
+    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:2355493a9e71f15d9004b2ab87892cb532e9e98db6882fced2912115eb5631af"},
+    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2798e42d62a0296982276d0bab96fc7d6772cd148357154348355304d6216763"},
+    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fe6acb1439127e0bee773f8a9a3ece290cb4cac4fe8d46b10bc8dda250a990c"},
+    {file = "grpcio-1.45.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6774272a59b9ee16fb0d4f53e23716953a22bbb3efe12fdf9a4ee3eec2c4f81f"},
+    {file = "grpcio-1.45.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:52f61fcb17d92b87ba47d54b3c9deae09d4f0216a3ea277b7df4b6c1794e6556"},
+    {file = "grpcio-1.45.0-cp39-cp39-win32.whl", hash = "sha256:3992c690228126e5652c7a1f61863c1ebfd71369cf2adb0fce86fee1d82d2d27"},
+    {file = "grpcio-1.45.0-cp39-cp39-win_amd64.whl", hash = "sha256:220867a53e53b2e201e98c55061e3053e31c0ce613625087242be684d3e8612a"},
+    {file = "grpcio-1.45.0.tar.gz", hash = "sha256:ff2c8b965b0fc25cf281961aa46619c10900543effe3f806ef818231c40aaff3"},
+]
+grpcio-tools = [
+    {file = "grpcio-tools-1.45.0.tar.gz", hash = "sha256:a016cfc21e0d91b3b036d3d4f968d1fdea865dfa03524cb1fbeca84719fd45a2"},
+    {file = "grpcio_tools-1.45.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:0431410ba4463bdb03051a6279c040a1bae1d1b12d7dd533ecfba2462725cf11"},
+    {file = "grpcio_tools-1.45.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:52a801063894a85f719108b438b8e71f86ca8059c25824944867879a4e8f6d2c"},
+    {file = "grpcio_tools-1.45.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:451e54b490c5d0efcb0ad7a8f7e45ec3cf452de67ee017ccb2bd1e5e45571938"},
+    {file = "grpcio_tools-1.45.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:047233beb9773f7da454711b3ec029233b494375db03f3fd2e759702b231c09f"},
+    {file = "grpcio_tools-1.45.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:210ea758250b5bb4f986713c01dc200f63b122a181a228114906bb99e5822479"},
+    {file = "grpcio_tools-1.45.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e021b911fde2f86c3528f67f7937a41ef56195f637a7556409a4e88c81ab8f2d"},
+    {file = "grpcio_tools-1.45.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ad8a74b0626b3762eeddfef2a18944f7cb9ddd80db13997fb4587185c821b10e"},
+    {file = "grpcio_tools-1.45.0-cp310-cp310-win32.whl", hash = "sha256:baceb0da2ada3ec4959beef208c3685d3274b0ecc59ac531658e0d35d8f67846"},
+    {file = "grpcio_tools-1.45.0-cp310-cp310-win_amd64.whl", hash = "sha256:ee423b5ebd1a6a6fa8d2cd4861a5ee758036e4d08f6a9a5eebc4ec2380bd94ef"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:e286083bcf32e7bc26b67c8fb8d59a385047cd1213e205a3f0eafee50c171cc4"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:f535902209809acf5d1de59e287dd43c81e76906d4e2e51f8068a544ecc84301"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:40842f52243c0ada1d6262a625bca31dd217e12ef7e7b3dbccaabe289d8b24e5"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:64ec376631be21e39a631b940dd833273fc709a19ad08d993089a7bb2a958dc0"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:b7de099ae16938aeb7c9e0f5178b9ad2be500731847e3a168be7dbad25d70dee"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bbee84e4fcaca03fbfb1b1defa7b226999d6fa468c72578ff900e46caf01a55b"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71a3beee3526b2aacbf19ad83a7737a1c9e4f8a1fad3768b644f9d8bf45f29df"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:57e79e34ba8ff1d7594dd5556fbeb1ff7bb985a9f34b54da65ea6c617c02969b"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d8656dca6e4f729a77a156cea16141dd7206657bf303b67c157530c7e7741216"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-win32.whl", hash = "sha256:527aa1105cf2ef8e979ccbb08b0e80330cbec736b67da54d966fc9f3860d7145"},
+    {file = "grpcio_tools-1.45.0-cp36-cp36m-win_amd64.whl", hash = "sha256:31bd8e8e5b383943e72b5fb8e157ee730aa6b52e8a15bb13035166e1b5b9c897"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:8f64dd3098edcdc99a0ee9e680ae674a86f40f65c125a88a11610c28503844ec"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:e8808de2aac8c7b2938602cd121b37b3c44e1e80cadb4b48dc695f205ff71e2c"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ebb17cb82cd921b8950ddc080ba5ed9a3fc06e45942050f6127872bd6fc46325"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0c1a1f1a794046823aac6ae207746b503b26db992837e7b06cb4bed2dc8520ae"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:8d9be3e3bf85820ce43ff00d800b6ad61448ab8c458c12c36696f76b81808aaa"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:319f4905e398558c9c0d508b685976b2728ff5c6629613debb6c153e49e5ad18"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7db11a65e07410db1c31cbeb9afe344a6bd88a63dcd819557707ca7318478727"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:477230d6d5054fc949928cbc1d50db54a5cece5d233b8ef3e0aebbf60939bdd8"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a33edaa319bafd7542105d25abc6d9a8a331d4684fb5886863d1c9a6cd47fa67"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-win32.whl", hash = "sha256:690b520660008687af9eb956981f6da2134f8ce299434a22314c00e9dac29fcb"},
+    {file = "grpcio_tools-1.45.0-cp37-cp37m-win_amd64.whl", hash = "sha256:47c6f5c7d9ed33726ed6ed1630767a8e08e8d10497cba07ba9001b54a599d486"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:bfea11559bec0935b84174a2bb10ec67ca97367d71d11facbbf9bbf8f5693067"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:36516f6f9957f6295d81766b1855be858055fc17cebcd4076471d697597cb2c6"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1b4b1727cdfda8854089f03df2d2b2b0171243c54048ac1359dd89ab5c211180"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b2425c9cbc1c400a4fd7adcefde7c524c46e7f42f3f2cb52a15399bc559d4fe0"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:1b4a5dcd433377cedb18cff3c79050c638ce7d6223de9ad9119157994558e37b"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed8306de5f8076d2fa0ba2a787c7fd1aecc4b901b2af1113acec21cea8178caf"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19ce25a2d573b2057af7d57aa7c80819db90cb92d20eafc8e8ae1448fe9941b1"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e3729ecd8bc42e783faba7243d315b1beb44021bc146afec0537791b47980878"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b7cf16c448e19b10f9fb13327d930925ef053bb21dcd858a20184d2a8f55ce18"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-win32.whl", hash = "sha256:367dfa639abc4538843043ab2dd6bf5b0232ddc519418f1e1287e855e7cf27c4"},
+    {file = "grpcio_tools-1.45.0-cp38-cp38-win_amd64.whl", hash = "sha256:115ae6a8df239987b662b228771ab9c1d4db3cc4db3da6d184a1b95bc9759d91"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:6e7b53a8a605f91e0f9584481b74b008f321ea22461f075eeaebaf98b2de372f"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:ad49ad7f6f5ea305d92ce33f773f7d9a667742010d1ec02a1a0626b735cf57dd"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:713ffedf8c01dc34c1d69121c0b3421f557674681ffc0e004205d9bb0fc994b9"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bf423863263933a98706e8a8b775c81d62e911222dbeb2b62ba60da815394ae2"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:5cfd3e7c082a3a01f65fdf3a3ab9168dea36102bf7326edfe03a1f592fe244e4"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6437665cd46e4dd39343c69da4c18f761868c632793ce6c436942d1b33fd930"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79d951338e18c90f9e412cbe3e747530c94bd7c71963574e70cf7cdb7c113c01"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:737d1c0e359b83f45b5d7170ea9bb08e5f90dd36126097b7a8e7ad62ade867be"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4b6e5c48eb28a215f9d6e76d646406d2505c1a5ae8864273960a73e5c09fe982"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-win32.whl", hash = "sha256:63d66c90f816601385a085726eb678c6c872aed7911df4232d906fc240159c83"},
+    {file = "grpcio_tools-1.45.0-cp39-cp39-win_amd64.whl", hash = "sha256:54dfd7d777664973b794b2fe585748f87f1066a4d6bb0af4f918b353b91bd434"},
+]
+protobuf = [
+    {file = "protobuf-3.20.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9d0f3aca8ca51c8b5e204ab92bd8afdb2a8e3df46bd0ce0bd39065d79aabcaa4"},
+    {file = "protobuf-3.20.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:001c2160c03b6349c04de39cf1a58e342750da3632f6978a1634a3dcca1ec10e"},
+    {file = "protobuf-3.20.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5b5860b790498f233cdc8d635a17fc08de62e59d4dcd8cdb6c6c0d38a31edf2b"},
+    {file = "protobuf-3.20.0-cp310-cp310-win32.whl", hash = "sha256:0b250c60256c8824219352dc2a228a6b49987e5bf94d3ffcf4c46585efcbd499"},
+    {file = "protobuf-3.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:a1eebb6eb0653e594cb86cd8e536b9b083373fca9aba761ade6cd412d46fb2ab"},
+    {file = "protobuf-3.20.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bc14037281db66aa60856cd4ce4541a942040686d290e3f3224dd3978f88f554"},
+    {file = "protobuf-3.20.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:47257d932de14a7b6c4ae1b7dbf592388153ee35ec7cae216b87ae6490ed39a3"},
+    {file = "protobuf-3.20.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fbcbb068ebe67c4ff6483d2e2aa87079c325f8470b24b098d6bf7d4d21d57a69"},
+    {file = "protobuf-3.20.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:542f25a4adf3691a306dcc00bf9a73176554938ec9b98f20f929a044f80acf1b"},
+    {file = "protobuf-3.20.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fd7133b885e356fa4920ead8289bb45dc6f185a164e99e10279f33732ed5ce15"},
+    {file = "protobuf-3.20.0-cp37-cp37m-win32.whl", hash = "sha256:8d84453422312f8275455d1cb52d850d6a4d7d714b784e41b573c6f5bfc2a029"},
+    {file = "protobuf-3.20.0-cp37-cp37m-win_amd64.whl", hash = "sha256:52bae32a147c375522ce09bd6af4d2949aca32a0415bc62df1456b3ad17c6001"},
+    {file = "protobuf-3.20.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:25d2fcd6eef340082718ec9ad2c58d734429f2b1f7335d989523852f2bba220b"},
+    {file = "protobuf-3.20.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:88c8be0558bdfc35e68c42ae5bf785eb9390d25915d4863bbc7583d23da77074"},
+    {file = "protobuf-3.20.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:38fd9eb74b852e4ee14b16e9670cd401d147ee3f3ec0d4f7652e0c921d6227f8"},
+    {file = "protobuf-3.20.0-cp38-cp38-win32.whl", hash = "sha256:7dcd84dc31ebb35ade755e06d1561d1bd3b85e85dbdbf6278011fc97b22810db"},
+    {file = "protobuf-3.20.0-cp38-cp38-win_amd64.whl", hash = "sha256:1eb13f5a5a59ca4973bcfa2fc8fff644bd39f2109c3f7a60bd5860cb6a49b679"},
+    {file = "protobuf-3.20.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1d24c81c2310f0063b8fc1c20c8ed01f3331be9374b4b5c2de846f69e11e21fb"},
+    {file = "protobuf-3.20.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:8be43a91ab66fe995e85ccdbdd1046d9f0443d59e060c0840319290de25b7d33"},
+    {file = "protobuf-3.20.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7a53d4035427b9dbfbb397f46642754d294f131e93c661d056366f2a31438263"},
+    {file = "protobuf-3.20.0-cp39-cp39-win32.whl", hash = "sha256:32bf4a90c207a0b4e70ca6dd09d43de3cb9898f7d5b69c2e9e3b966a7f342820"},
+    {file = "protobuf-3.20.0-cp39-cp39-win_amd64.whl", hash = "sha256:6efe066a7135233f97ce51a1aa007d4fb0be28ef093b4f88dac4ad1b3a2b7b6f"},
+    {file = "protobuf-3.20.0-py2.py3-none-any.whl", hash = "sha256:4eda68bd9e2a4879385e6b1ea528c976f59cd9728382005cc54c28bcce8db983"},
+    {file = "protobuf-3.20.0.tar.gz", hash = "sha256:71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "okp4_grpc_client"
-version = "1.0.0"
+version = "0.1.0"
 description = "Python gRPC client for ØKP4 and by extension, CØSMOS based blockchains."
 authors = ["OKP4 <opensource@okp4.com>"]
 readme = "README.md"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,12 @@ name = "okp4_grpc_client"
 version = "1.0.0"
 description = "Python gRPC client for ØKP4 and by extension, CØSMOS based blockchains."
 authors = ["OKP4 <opensource@okp4.com>"]
+readme = "README.md"
 license = "BSD-3-Clause"
+repository = "https://github.com/okp4/okp4-cosmos-proto"
+include = [
+    "LICENSE",
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "okp4_grpc_client"
+version = "1.0.0"
+description = "Python gRPC client for ØKP4 and by extension, CØSMOS based blockchains."
+authors = ["OKP4 <opensource@okp4.com>"]
+license = "BSD-3-Clause"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+
+[tool.poetry.dev-dependencies]
+grpcio = "^1.45.0"
+grpcio-tools = "^1.45.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Purpose

Provides Python [gRPC clients](https://grpc.io/docs/languages/python/quickstart/) for ØKP4 and by extension, CØSMOS based blockchains generated from their Protobuf definitions.

## Why

At OKP4, we mainly use 3 programming languages: Typescript for the frontend, Kotlin and Python for the backend. 
Thereforce, it seems useful to us to have a generated grpc client for cases where we are likely to develop services in python that interact directly with the blockchain. 

## How

The implementation uses the same recipes from @amimart for Kotlin and Typescript generations, but relies on [poetry](https://python-poetry.org/) for packaging and dependency management.

The generated code is packgaged and published to [pypi](https://pypi.org/) on release.