### PR TITLE
feat: generate reflection config task

### DIFF
--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -30,7 +30,6 @@ fun prepareVersion(): String {
         }.joinToString(".") + project.hasProperty("release").let { if (it) "" else "-SNAPSHOT" }
 }
 
-
 afterEvaluate {
     project.version = prepareVersion()
 }
@@ -73,7 +72,6 @@ subprojects {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
         }
-        finalizedBy("genReflectConfig")
     }
 
     protobuf {
@@ -99,11 +97,6 @@ subprojects {
                 }
             }
         }
-    }
-
-    tasks.register("genReflectConfig", GenerateReflectionConfig::class) {
-        configPath = "reflection-config.json"
-        packageNames = listOf("cosmos", "tendermint", "cosmos_proto", "okp4-cosmos-proto.okp4")
     }
 
     configure<PublishingExtension> {

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -73,6 +73,7 @@ subprojects {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
         }
+        finalizedBy("genReflectConfig")
     }
 
     protobuf {
@@ -98,6 +99,11 @@ subprojects {
                 }
             }
         }
+    }
+
+    tasks.register("genReflectConfig", GenerateReflectionConfig::class) {
+        configPath = "reflection-config.json"
+        packageNames = listOf("cosmos", "tendermint", "cosmos_proto", "okp4-cosmos-proto.okp4")
     }
 
     configure<PublishingExtension> {

--- a/kotlin/buildSrc/build.gradle.kts
+++ b/kotlin/buildSrc/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.5.31"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Use the Kotlin JDK 8 standard library.
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+
+    val grpcVersion = "1.45.0"
+    api("io.grpc:grpc-stub:$grpcVersion")
+    api("io.grpc:grpc-protobuf:$grpcVersion")
+
+    val protobufVersion = "3.19.4"
+    api("com.google.protobuf:protobuf-java-util:$protobufVersion")
+    api("com.google.protobuf:protobuf-kotlin:$protobufVersion")
+
+    val grpcKotlinVersion = "1.2.1"
+    api("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
+
+    api("com.google.code.gson:gson:2.9.0")
+    api(gradleApi())
+    api(kotlin("reflect"))
+    api("org.reflections:reflections:0.10.2")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}

--- a/kotlin/buildSrc/build.gradle.kts
+++ b/kotlin/buildSrc/build.gradle.kts
@@ -10,21 +10,15 @@ dependencies {
     // Use the Kotlin JDK 8 standard library.
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    val grpcVersion = "1.45.0"
-    api("io.grpc:grpc-stub:$grpcVersion")
-    api("io.grpc:grpc-protobuf:$grpcVersion")
+    val classgraphVersion = "4.8.146"
+    api("io.github.classgraph:classgraph:$classgraphVersion")
 
     val protobufVersion = "3.19.4"
     api("com.google.protobuf:protobuf-java-util:$protobufVersion")
-    api("com.google.protobuf:protobuf-kotlin:$protobufVersion")
 
-    val grpcKotlinVersion = "1.2.1"
-    api("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
-
-    api("com.google.code.gson:gson:2.9.0")
+    val gsonVersion = "2.9.0"
+    api("com.google.code.gson:gson:$gsonVersion")
     api(gradleApi())
-    api(kotlin("reflect"))
-    api("org.reflections:reflections:0.10.2")
 }
 
 java {

--- a/kotlin/buildSrc/settings.gradle.kts
+++ b/kotlin/buildSrc/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "reflection-task"

--- a/kotlin/buildSrc/src/main/kotlin/ReflectionTask.kt
+++ b/kotlin/buildSrc/src/main/kotlin/ReflectionTask.kt
@@ -60,7 +60,7 @@ open class GenerateReflectionConfig : DefaultTask() {
                             Descriptors.Descriptor::class.java.let { c ->
                                 ReflectionConfig(
                                     name = c.name,
-                                    methods = c.methods .map {
+                                    methods = c.methods.map {
                                         ReflectionMethod(
                                             name = it.name,
                                             parameterTypes = it.parameterTypes.map { param ->

--- a/kotlin/buildSrc/src/main/kotlin/ReflectionTask.kt
+++ b/kotlin/buildSrc/src/main/kotlin/ReflectionTask.kt
@@ -1,0 +1,69 @@
+import com.google.gson.GsonBuilder
+import com.google.protobuf.Descriptors
+import com.google.protobuf.GeneratedMessageV3
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.reflections.Reflections
+import java.io.File
+
+data class ReflectionMethod(
+    val name: String,
+    val parameterTypes: List<String>
+)
+
+data class ReflectionConfig(
+    val name: String,
+    val methods: List<ReflectionMethod>,
+)
+
+open class GenerateReflectionConfig : DefaultTask() {
+    @Input
+    lateinit var configPath: String
+    
+    @Input
+    lateinit var packageNames: List<String>
+
+    @TaskAction
+    fun generateReflectionConfigJSON() =
+        File(configPath).writeText(
+            GsonBuilder().setPrettyPrinting().create()
+                .toJson(
+                    packageNames.asSequence().map { Reflections(it) }
+                        .map { reflections ->
+                            reflections.getSubTypesOf(GeneratedMessageV3::class.java)
+                                .map { it.name }
+                        }
+                        .flatten()
+                        .map { className ->
+                            ReflectionConfig(
+                                name = className,
+                                methods = listOf(
+                                    ReflectionMethod(
+                                        name = "getDescriptor",
+                                        parameterTypes = emptyList()
+                                    )
+                                )
+                            )
+                        }
+                        .toMutableList()
+                        .apply {
+                            this.add(
+                                Descriptors.Descriptor::class.java.let { c ->
+                                    ReflectionConfig(
+                                        name = c.name,
+                                        methods = c.methods .map {
+                                            ReflectionMethod(
+                                                name = it.name,
+                                                parameterTypes = it.parameterTypes.map { param ->
+                                                    param.name
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                )
+        )
+}

--- a/kotlin/modules/cosmos-sdk/build.gradle.kts
+++ b/kotlin/modules/cosmos-sdk/build.gradle.kts
@@ -6,6 +6,19 @@ sourceSets {
     }
 }
 
+tasks {
+    val reflectionConfiguration = register<GenerateReflectionConfig>("reflectionConfiguration") {
+        dependsOn.addAll(listOf("compileJava"))
+
+        output = "${sourceSets.main.get().output.resourcesDir!!.absolutePath}/reflection-config.json"
+        sources = sourceSets.main.get().output.classesDirs.files.toList().map { it.path }
+    }
+
+    jar {
+        dependsOn.add(reflectionConfiguration)
+    }
+}
+
 publishing {
     publications {
         create<MavenPublication>("cosmos") {

--- a/kotlin/modules/okp4/build.gradle.kts
+++ b/kotlin/modules/okp4/build.gradle.kts
@@ -10,6 +10,19 @@ dependencies {
     implementation(project(":cosmos-sdk"))
 }
 
+tasks {
+    val reflectionConfiguration = register<GenerateReflectionConfig>("reflectionConfiguration") {
+        dependsOn.addAll(listOf("compileJava"))
+
+        output = "${sourceSets.main.get().output.resourcesDir!!.absolutePath}/reflection-config.json"
+        sources = sourceSets.main.get().output.classesDirs.files.toList().map { it.path }
+    }
+
+    jar {
+        dependsOn.add(reflectionConfiguration)
+    }
+}
+
 publishing {
     publications {
         create<MavenPublication>("okp4") {


### PR DESCRIPTION
Generate GraalVM reflection configuration file: `reflection-config.json` for each kotlin modules.

The reflection configuration currently exposes the `getDescriptor()` method of all subclasses of `GeneratedMessageV3` & all the methods of the `Descriptors.Descriptor` class.

The `reflection-config.json` file is generated before embedding it in each jar.