### PR TITLE
build: prevent null property error in kotlin local build

### DIFF
--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -105,8 +105,8 @@ subprojects {
                 name = "GitHubPackages"
                 url = uri("https://maven.pkg.github.com/okp4/${rootProject.name}")
                 credentials {
-                    username = project.property("maven.credentials.username") as String
-                    password = project.property("maven.credentials.password") as String
+                    username = project.findProperty("maven.credentials.username") as String?
+                    password = project.findProperty("maven.credentials.password") as String?
                 }
             }
         }


### PR DESCRIPTION
A fix to error occuring in kotlin project local build when variables `maven.credential.username` and `maven.credential.password` are not set in the `gradle.properties` file. 