### PR TITLE
Docs/rust target

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ Generate gRPC clients for multiple targets based on [CØSMOS](https://github.com
 - [Kotlin](kotlin/README.md)
 - [Typescript (grpc-web)](ts/README.md)
 - [Python (cosmos-sdk-grpc-client)](python/cosmos_sdk_grpc_client/README.md), [Python (okp4-grpc-client)](python/okp4_grpc_client/README.md)
+- [Rust (cosmos-sdk-grpc-client)](rust/cosmos_sdk_grpc_client/README.md), [Rust (okp4-grpc-client)](rust/okp4_grpc_client/README.md)

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Generate gRPC clients for multiple targets based on [CØSMOS](https://github.com
 
 - [Kotlin](kotlin/README.md)
 - [Typescript (grpc-web)](ts/README.md)
-- [Python](python/README.md)
+- [Python (cosmos-sdk-grpc-client)](python/cosmos_sdk_grpc_client/README.md), [Python (okp4-grpc-client)](python/okp4_grpc_client/README.md)

--- a/rust/cosmos_sdk_grpc_client/README.md
+++ b/rust/cosmos_sdk_grpc_client/README.md
@@ -3,7 +3,7 @@
 > Rust gRPC client for CØSMOS SDK based blockchains.
 
 [![build](https://github.com/okp4/okp4-cosmos-proto/actions/workflows/build.yml/badge.svg)](https://github.com/okp4/okp4-cosmos-proto/actions/workflows/build.yml)
-[![PyPI](https://img.shields.io/crates/v/cosmos_sdk_grpc_client)](https://crates.io/crates/cosmos_sdk_grpc_client)
+[![crates](https://img.shields.io/crates/v/cosmos_sdk_grpc_client)](https://crates.io/crates/cosmos_sdk_grpc_client)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
 ## Purpose

--- a/rust/okp4_grpc_client/README.md
+++ b/rust/okp4_grpc_client/README.md
@@ -3,7 +3,7 @@
 > Rust gRPC client for ØKP4 specific modules of our CØSMOS SDK based blockchain.
 
 [![build](https://github.com/okp4/okp4-cosmos-proto/actions/workflows/build.yml/badge.svg)](https://github.com/okp4/okp4-cosmos-proto/actions/workflows/build.yml)
-[![PyPI](https://img.shields.io/crates/v/okp4_grpc_client)](https://crates.io/crates/cosmos_sdk_grpc_client)
+[![crates](https://img.shields.io/crates/v/okp4_grpc_client)](https://crates.io/crates/cosmos_sdk_grpc_client)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
 ## Purpose


### PR DESCRIPTION
Add links to Rust targets in `README.md` (+ minor fixes on links).